### PR TITLE
Add Phi audit check to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,14 @@ repos:
       - id: check-toml
       - id: check-merge-conflict
       - id: debug-statements
+
+  # ─────────────────────────────────────────────
+  # Phi-check — Audit local pour bloquer le code/piratage/lourds risques
+  # ─────────────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: phi-check
+        name: "Phi audit check"
+        entry: python phi_check.py
+        language: python
+        stages: [commit]


### PR DESCRIPTION
Added a local hook for Phi audit check to pre-commit configuration.

## 📋 Description
<!-- Décris brièvement les changements apportés et leur motivation -->



## 🔗 Issue liée
<!-- Ferme #<numéro> ou Référence #<numéro> -->
Closes #

## 🧪 Type de changement
<!-- Coche les cases qui correspondent -->
- [ ] 🐛 Correction de bug
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring (pas de changement fonctionnel)
- [ ] 📚 Documentation
- [ ] 🔒 Sécurité / Protection
- [ ] ⚙️ CI/CD / Outillage

## ✅ Checklist qualité
<!-- Assure-toi que toutes les cases sont cochées avant de demander une revue -->
- [ ] Mon code suit le style du projet
- [ ] J'ai ajouté ou mis à jour les tests correspondants
- [ ] Les tests locaux passent (`pytest tests/`)
- [ ] La vérification de type est propre (`mypy phi_complexity/`)
- [ ] L'audit phi passe (`python -m phi_complexity.cli check . --min-radiance 50`)
- [ ] La documentation a été mise à jour si nécessaire
- [ ] Aucun secret ni donnée sensible n'est inclus dans le diff

## 🖼️ Captures d'écran (si applicable)
<!-- Ajoute des captures d'écran pour les changements visuels -->

## 💬 Contexte supplémentaire
<!-- Tout autre élément utile pour les reviewers -->
