### PR TITLE
Add phi_check.py for keyword blocking in commits

### DIFF
--- a/phi_check.py
+++ b/phi_check.py
@@ -1,0 +1,20 @@
+import sys
+import pathlib
+
+BLOCKED_KEYWORDS = [
+    'nmap', 'metasploit', 'crack', 'bruteforce', 'reverse shell', 'hydra', 'john'
+]
+
+for file in sys.argv[1:]:
+    path = pathlib.Path(file)
+    if path.is_file():
+        try:
+            text = path.read_text(errors='ignore').lower()
+            for keyword in BLOCKED_KEYWORDS:
+                if keyword in text:
+                    print(f"❌ Commit bloqué : Le fichier '{file}' contient le mot clé interdit : '{keyword}'")
+                    sys.exit(1)
+        except Exception:
+            continue
+print("✅ Audit phi-check réussi.")
+sys.exit(0)


### PR DESCRIPTION
Implement a script to block commits containing certain keywords.

## 📋 Description
<!-- Décris brièvement les changements apportés et leur motivation -->



## 🔗 Issue liée
<!-- Ferme #<numéro> ou Référence #<numéro> -->
Closes #

## 🧪 Type de changement
<!-- Coche les cases qui correspondent -->
- [ ] 🐛 Correction de bug
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 🔧 Refactoring (pas de changement fonctionnel)
- [ ] 📚 Documentation
- [ ] 🔒 Sécurité / Protection
- [ ] ⚙️ CI/CD / Outillage

## ✅ Checklist qualité
<!-- Assure-toi que toutes les cases sont cochées avant de demander une revue -->
- [ ] Mon code suit le style du projet
- [ ] J'ai ajouté ou mis à jour les tests correspondants
- [ ] Les tests locaux passent (`pytest tests/`)
- [ ] La vérification de type est propre (`mypy phi_complexity/`)
- [ ] L'audit phi passe (`python -m phi_complexity.cli check . --min-radiance 50`)
- [ ] La documentation a été mise à jour si nécessaire
- [ ] Aucun secret ni donnée sensible n'est inclus dans le diff

## 🖼️ Captures d'écran (si applicable)
<!-- Ajoute des captures d'écran pour les changements visuels -->

## 💬 Contexte supplémentaire
<!-- Tout autre élément utile pour les reviewers -->
